### PR TITLE
Return payment details as they are returned by the OP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.3.2
+- Not use default response in payments_details endpoint
+
 1.3.1
 - Handle payment_details_endpoint http code 204
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,34 @@ An example data object:
 }
 ```
 
+<br>
+
+### paymentDetailsInfo
+
+Returns the payment details information
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+expectedIssuer, accessToken, options
+| `expectedIssuer` | `string` | **Required**. The issuer url. It must be the same than the one used to get the authorization url
+| `accessToken` | `object` | **Required**. The token object returned by the `token` or `refreshToken` function
+| `options` | `object` | **Optional**. The options object to inject in the requestResource method in the openid-client lib
+
+An example data object:
+
+```javascript
+[
+  {
+    bankId: "125000024",
+    identifier: "454992210071",
+    identifierType: "ACCOUNT_NUMBER",
+    type: "US_ACH",
+    transferIn: true,
+    transferOut: true,
+    accountId: "g833202fb0866d0ad83472c429"
+  }
+]
+```
 ## Testing
 
 ```

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -150,11 +150,10 @@ class IDPartner {
 
     const response = await client.requestResource(client.issuer.payment_details_info_endpoint, accessToken, options);
     const status = response.statusCode;
-    const data = response.body?.toString('utf8') || '[]';
     if (status >= 400 && status < 600) {
-      throw new Error(`Failed to get the bank accounts info. Data: ${data}, Status: ${status}`);
+      throw new Error(`Failed to get the bank accounts info. Data: ${response.body}, Status: ${status}`);
     }
-    return JSON.parse(data);
+    return JSON.parse(response.body);
   }
 
   async credential(expectedIssuer, accessToken, body) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {


### PR DESCRIPTION
In the version previous to this PR we used to return an empty array of no response was returned by the OP. We are updating the library to be less opinionated and trust the value returned by the OP.

OPs should, in the worst case return a 200 with an empty array. Otherwise, the function would throw an error.
