### PR TITLE
Dev 867 add support for client secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.4.0
+
+- Add support for client-secret and preserve the jwt old usage
+
 1.3.2
 - Not use default response in payments_details endpoint
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -61,9 +61,12 @@ class IDPartner {
   }
 
   async #getAccessToken(client, codeResponse, { state, nonce, codeVerifier }, options={}) {
-    // const params = { response: codeResponse }; // new sdk jwt not valid anymore
-    const params = client.callbackParams(codeResponse); // new sdk client secret
-    console.log('gio: params idpartner.js', params);
+    let params;
+    if (codeResponse.indexOf('?') > -1) {
+      params = client.callbackParams(codeResponse); // new sdk client secret
+    } else {
+      params = { response: codeResponse }; // new sdk jwt not valid anymore
+    }
     return client.callback(client.redirect_uris[0], params, { state, nonce, code_verifier: codeVerifier }, options);
   };
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -6,8 +6,8 @@ const { HTTPClient } = require('@idpartner/http-client');
 const { logger } = require('@idpartner/logger');
 
 const SIGNING_ALG = 'PS256';
-// const ENCRYPTION_ALG = 'RSA-OAEP';
-// const ENCRYPTION_ENC = 'A256CBC-HS512';
+const ENCRYPTION_ALG = 'RSA-OAEP';
+const ENCRYPTION_ENC = 'A256CBC-HS512';
 const DEFAULT_TIMEOUT_IN_MILLIS = 3500;
 
 const createClient = async (config, issuer) => {
@@ -23,17 +23,17 @@ const createClient = async (config, issuer) => {
     {
       client_id: clientId,
       client_secret: clientSecret,
-      // token_endpoint_auth_method: 'client_secret_basic',
+      token_endpoint_auth_method: 'private_key_jwt', // jwt
       redirect_uris: redirectUri.split(','),
-      // authorization_signed_response_alg: SIGNING_ALG,
-      // authorization_encrypted_response_alg: ENCRYPTION_ALG,
-      // authorization_encrypted_response_enc: ENCRYPTION_ENC,
+      authorization_signed_response_alg: SIGNING_ALG, // jwt
+      authorization_encrypted_response_alg: ENCRYPTION_ALG, // jwt
+      authorization_encrypted_response_enc: ENCRYPTION_ENC, // jwt
       id_token_signed_response_alg: SIGNING_ALG,
-      // id_token_encrypted_response_alg: ENCRYPTION_ALG,
-      // id_token_encrypted_response_enc: ENCRYPTION_ENC,
-      // request_object_signing_alg: SIGNING_ALG,
+      id_token_encrypted_response_alg: ENCRYPTION_ALG, // jwt
+      id_token_encrypted_response_enc: ENCRYPTION_ENC, // jwt
+      request_object_signing_alg: SIGNING_ALG, // jwt
     },
-    // jwks,
+    jwks, // jwt
   );
 };
 
@@ -61,8 +61,8 @@ class IDPartner {
   }
 
   async #getAccessToken(client, codeResponse, { state, nonce, codeVerifier }, options={}) {
-    // const params = { response: codeResponse };
-    const params = client.callbackParams(codeResponse);
+    // const params = { response: codeResponse }; // new sdk jwt not valid anymore
+    const params = client.callbackParams(codeResponse); // new sdk client secret
     console.log('gio: params idpartner.js', params);
     return client.callback(client.redirect_uris[0], params, { state, nonce, code_verifier: codeVerifier }, options);
   };
@@ -97,8 +97,8 @@ class IDPartner {
     const codeChallenge = generators.codeChallenge(codeVerifier);
 
     const client = await this.#getClient(iss);
-    // const requestObject = client.requestObject({
-    return client.authorizationUrl({
+    // return client.authorizationUrl({
+    const requestObject = await client.requestObject({ // jwt
       redirect_uri: redirectUri,
       code_challenge_method: 'S256',
       code_challenge: codeChallenge,
@@ -106,18 +106,20 @@ class IDPartner {
       nonce,
       scope: scope.join(' '),
       prompt,
+      // response_mode: 'jwt',  // jwt not use because provider has it off
       response_type: 'code',
       client_id: clientId,
-      client_secret: clientSecret,
+      // client_secret: clientSecret, // client-secret
       nbf: Math.floor(new Date().getTime() / 1000),
       'x-fapi-interaction-id': uuidv4(),
       identity_provider_id: query.idp_id,
       idpartner_token: idpartnerToken,
     });
 
-    // const { request_uri } = await client.pushedAuthorizationRequest({ request: requestObject });
-    // const queryParams = new URLSearchParams({ request_uri });
-    // return `${client.issuer.authorization_endpoint}?${queryParams}`;
+    // jwt
+    const { request_uri } = await client.pushedAuthorizationRequest({ request: requestObject });
+    const queryParams = new URLSearchParams({ request_uri });
+    return `${client.issuer.authorization_endpoint}?${queryParams}`;
   }
 
   // Legacy function to fetch the user info using the authorization code. This is an optimization of the more verbose version

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -70,13 +70,7 @@ class IDPartner {
   }
 
   async #getAccessToken(client, codeResponse, { state, nonce, codeVerifier }, options={}) {
-    let params;
-    if (codeResponse.indexOf('?') > -1) {
-      params = client.callbackParams(codeResponse);
-    } else {
-      // TODO: when private_key_jwt is deprecated remove this bifurcation
-      params = { response: codeResponse };
-    }
+    const params = client.callbackParams(codeResponse);
     return client.callback(client.redirect_uris[0], params, { state, nonce, code_verifier: codeVerifier }, options);
   };
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -106,7 +106,7 @@ class IDPartner {
       nonce,
       scope: scope.join(' '),
       prompt,
-      // response_mode: 'jwt',  // jwt not use because provider has it off
+      response_mode: 'jwt',  // jwt not use because provider has it off
       response_type: 'code',
       client_id: clientId,
       // client_secret: clientSecret, // client-secret

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -11,6 +11,7 @@ const ENCRYPTION_ENC = 'A256CBC-HS512';
 const DEFAULT_TIMEOUT_IN_MILLIS = 3500;
 
 const createClient = async (config, issuer) => {
+  console.log('poc');
   const clientId = config.client_id;
   const clientSecret = config.client_secret;
   const redirectUri = config.callback;
@@ -109,8 +110,9 @@ class IDPartner {
 
     const { state, nonce, codeVerifier } = proofs;
     const codeChallenge = generators.codeChallenge(codeVerifier);
-
     const client = await this.#getClient(iss);
+    let parResponse;
+
     const params = {
       redirect_uri: redirectUri,
       code_challenge_method: 'S256',
@@ -125,14 +127,16 @@ class IDPartner {
       identity_provider_id: query.idp_id,
       idpartner_token: idpartnerToken,
     };
-
     if (clientSecret) {
       params.client_secret = clientSecret;
+      parResponse = await client.pushedAuthorizationRequest(params);
     } else {
       params.response_mode = 'jwt';
+      const resquestObject = client.requestObject(params);
+      parResponse = await client.pushedAuthorizationRequest({ request: requestObject });
     }
+    const { request_uri } = parResponse;
 
-    const { request_uri } = await client.pushedAuthorizationRequest(params);
     const queryParams = new URLSearchParams({ request_uri });
     return `${client.issuer.authorization_endpoint}?${queryParams}`;
   }

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -31,7 +31,6 @@ const createClient = async (config, issuer) => {
     return new issuer.Client(
       {
         client_id: clientId,
-        client_secret: clientSecret,
         token_endpoint_auth_method: 'private_key_jwt',
         redirect_uris: redirectUri.split(','),
         authorization_signed_response_alg: SIGNING_ALG,

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -19,22 +19,32 @@ const createClient = async (config, issuer) => {
     timeout: parseInt(config.timeout) || DEFAULT_TIMEOUT_IN_MILLIS,
   });
 
-  return new issuer.Client(
-    {
+  if (clientSecret) {
+    return new issuer.Client({
       client_id: clientId,
       client_secret: clientSecret,
-      token_endpoint_auth_method: 'private_key_jwt', // jwt
       redirect_uris: redirectUri.split(','),
-      authorization_signed_response_alg: SIGNING_ALG, // jwt
-      authorization_encrypted_response_alg: ENCRYPTION_ALG, // jwt
-      authorization_encrypted_response_enc: ENCRYPTION_ENC, // jwt
       id_token_signed_response_alg: SIGNING_ALG,
-      id_token_encrypted_response_alg: ENCRYPTION_ALG, // jwt
-      id_token_encrypted_response_enc: ENCRYPTION_ENC, // jwt
-      request_object_signing_alg: SIGNING_ALG, // jwt
-    },
-    jwks, // jwt
-  );
+      authorization_signed_response_alg: SIGNING_ALG,
+    });
+  } else {
+    return new issuer.Client(
+      {
+        client_id: clientId,
+        client_secret: clientSecret,
+        token_endpoint_auth_method: 'private_key_jwt',
+        redirect_uris: redirectUri.split(','),
+        authorization_signed_response_alg: SIGNING_ALG,
+        authorization_encrypted_response_alg: ENCRYPTION_ALG,
+        authorization_encrypted_response_enc: ENCRYPTION_ENC,
+        id_token_signed_response_alg: SIGNING_ALG,
+        id_token_encrypted_response_alg: ENCRYPTION_ALG,
+        id_token_encrypted_response_enc: ENCRYPTION_ENC,
+        request_object_signing_alg: SIGNING_ALG,
+      },
+      jwks,
+    );
+  }
 };
 
 const createHttpClient = iss => HTTPClient({ baseURL: iss, logger });;
@@ -63,9 +73,10 @@ class IDPartner {
   async #getAccessToken(client, codeResponse, { state, nonce, codeVerifier }, options={}) {
     let params;
     if (codeResponse.indexOf('?') > -1) {
-      params = client.callbackParams(codeResponse); // new sdk client secret
+      params = client.callbackParams(codeResponse);
     } else {
-      params = { response: codeResponse }; // new sdk jwt not valid anymore
+      // TODO: when private_key_jwt is deprecated remove this bifurcation
+      params = { response: codeResponse };
     }
     return client.callback(client.redirect_uris[0], params, { state, nonce, code_verifier: codeVerifier }, options);
   };
@@ -100,8 +111,7 @@ class IDPartner {
     const codeChallenge = generators.codeChallenge(codeVerifier);
 
     const client = await this.#getClient(iss);
-    // return client.authorizationUrl({
-    const requestObject = await client.requestObject({ // jwt
+    const params = {
       redirect_uri: redirectUri,
       code_challenge_method: 'S256',
       code_challenge: codeChallenge,
@@ -109,18 +119,20 @@ class IDPartner {
       nonce,
       scope: scope.join(' '),
       prompt,
-      response_mode: 'jwt',  // jwt not use because provider has it off
-      response_type: 'code',
       client_id: clientId,
-      // client_secret: clientSecret, // client-secret
       nbf: Math.floor(new Date().getTime() / 1000),
       'x-fapi-interaction-id': uuidv4(),
       identity_provider_id: query.idp_id,
       idpartner_token: idpartnerToken,
-    });
+    };
 
-    // jwt
-    const { request_uri } = await client.pushedAuthorizationRequest({ request: requestObject });
+    if (clientSecret) {
+      params.client_secret = clientSecret;
+    } else {
+      params.response_mode = 'jwt';
+    }
+
+    const { request_uri } = await client.pushedAuthorizationRequest(params);
     const queryParams = new URLSearchParams({ request_uri });
     return `${client.issuer.authorization_endpoint}?${queryParams}`;
   }

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -6,12 +6,13 @@ const { HTTPClient } = require('@idpartner/http-client');
 const { logger } = require('@idpartner/logger');
 
 const SIGNING_ALG = 'PS256';
-const ENCRYPTION_ALG = 'RSA-OAEP';
-const ENCRYPTION_ENC = 'A256CBC-HS512';
+// const ENCRYPTION_ALG = 'RSA-OAEP';
+// const ENCRYPTION_ENC = 'A256CBC-HS512';
 const DEFAULT_TIMEOUT_IN_MILLIS = 3500;
 
 const createClient = async (config, issuer) => {
   const clientId = config.client_id;
+  const clientSecret = config.client_secret;
   const redirectUri = config.callback;
   const jwks = config.jwks;
   custom.setHttpOptionsDefaults({
@@ -21,17 +22,18 @@ const createClient = async (config, issuer) => {
   return new issuer.Client(
     {
       client_id: clientId,
-      token_endpoint_auth_method: 'private_key_jwt',
+      client_secret: clientSecret,
+      // token_endpoint_auth_method: 'client_secret_basic',
       redirect_uris: redirectUri.split(','),
-      authorization_signed_response_alg: SIGNING_ALG,
-      authorization_encrypted_response_alg: ENCRYPTION_ALG,
-      authorization_encrypted_response_enc: ENCRYPTION_ENC,
+      // authorization_signed_response_alg: SIGNING_ALG,
+      // authorization_encrypted_response_alg: ENCRYPTION_ALG,
+      // authorization_encrypted_response_enc: ENCRYPTION_ENC,
       id_token_signed_response_alg: SIGNING_ALG,
-      id_token_encrypted_response_alg: ENCRYPTION_ALG,
-      id_token_encrypted_response_enc: ENCRYPTION_ENC,
-      request_object_signing_alg: SIGNING_ALG,
+      // id_token_encrypted_response_alg: ENCRYPTION_ALG,
+      // id_token_encrypted_response_enc: ENCRYPTION_ENC,
+      // request_object_signing_alg: SIGNING_ALG,
     },
-    jwks,
+    // jwks,
   );
 };
 
@@ -59,8 +61,10 @@ class IDPartner {
   }
 
   async #getAccessToken(client, codeResponse, { state, nonce, codeVerifier }, options={}) {
-    const params = { response: codeResponse };
-    return client.callback(client.redirect_uris[0], params, { jarm: true, state, nonce, code_verifier: codeVerifier }, options);
+    // const params = { response: codeResponse };
+    const params = client.callbackParams(codeResponse);
+    console.log('gio: params idpartner.js', params);
+    return client.callback(client.redirect_uris[0], params, { state, nonce, code_verifier: codeVerifier }, options);
   };
 
   async getPublicJWKs() {
@@ -75,6 +79,7 @@ class IDPartner {
   async getAuthorizationUrl(query, proofs, scope, prompt) {
     const {
       client_id: clientId,
+      client_secret: clientSecret,
       account_selector_service_url: accountSelectorServiceUrl,
       callback: redirectUri
     } = this.config;
@@ -92,7 +97,8 @@ class IDPartner {
     const codeChallenge = generators.codeChallenge(codeVerifier);
 
     const client = await this.#getClient(iss);
-    const requestObject = await client.requestObject({
+    // const requestObject = client.requestObject({
+    return client.authorizationUrl({
       redirect_uri: redirectUri,
       code_challenge_method: 'S256',
       code_challenge: codeChallenge,
@@ -100,18 +106,18 @@ class IDPartner {
       nonce,
       scope: scope.join(' '),
       prompt,
-      response_mode: 'jwt',
       response_type: 'code',
       client_id: clientId,
+      client_secret: clientSecret,
       nbf: Math.floor(new Date().getTime() / 1000),
       'x-fapi-interaction-id': uuidv4(),
       identity_provider_id: query.idp_id,
       idpartner_token: idpartnerToken,
     });
 
-    const { request_uri } = await client.pushedAuthorizationRequest({ request: requestObject });
-    const queryParams = new URLSearchParams({ request_uri });
-    return `${client.issuer.authorization_endpoint}?${queryParams}`;
+    // const { request_uri } = await client.pushedAuthorizationRequest({ request: requestObject });
+    // const queryParams = new URLSearchParams({ request_uri });
+    // return `${client.issuer.authorization_endpoint}?${queryParams}`;
   }
 
   // Legacy function to fetch the user info using the authorization code. This is an optimization of the more verbose version

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -11,7 +11,6 @@ const ENCRYPTION_ENC = 'A256CBC-HS512';
 const DEFAULT_TIMEOUT_IN_MILLIS = 3500;
 
 const createClient = async (config, issuer) => {
-  console.log('poc');
   const clientId = config.client_id;
   const clientSecret = config.client_secret;
   const redirectUri = config.callback;
@@ -111,7 +110,7 @@ class IDPartner {
     const { state, nonce, codeVerifier } = proofs;
     const codeChallenge = generators.codeChallenge(codeVerifier);
     const client = await this.#getClient(iss);
-    let parResponse;
+    let response;
 
     const params = {
       redirect_uri: redirectUri,
@@ -121,6 +120,7 @@ class IDPartner {
       nonce,
       scope: scope.join(' '),
       prompt,
+      response_type: 'code',
       client_id: clientId,
       nbf: Math.floor(new Date().getTime() / 1000),
       'x-fapi-interaction-id': uuidv4(),
@@ -129,13 +129,13 @@ class IDPartner {
     };
     if (clientSecret) {
       params.client_secret = clientSecret;
-      parResponse = await client.pushedAuthorizationRequest(params);
+      response = await client.pushedAuthorizationRequest(params);
     } else {
       params.response_mode = 'jwt';
-      const resquestObject = client.requestObject(params);
-      parResponse = await client.pushedAuthorizationRequest({ request: requestObject });
+      const requestObject = await client.requestObject(params);
+      response = await client.pushedAuthorizationRequest({ request: requestObject });
     }
-    const { request_uri } = parResponse;
+    const { request_uri } = response;
 
     const queryParams = new URLSearchParams({ request_uri });
     return `${client.issuer.authorization_endpoint}?${queryParams}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {

--- a/test/idpartner.test.js
+++ b/test/idpartner.test.js
@@ -77,6 +77,9 @@ describe('id-partner', function () {
     clientFullUserInfoMockFn = jest.fn().mockReturnValue(ISSUER_FULL_USERINFO_RESPONSE);
     clientRequestObjectMockFn = jest.fn().mockReturnValue(ISSUER_REQUEST_OBJECT);
     clientPushedAuthRequestMockFn = jest.fn().mockReturnValue(ISSUER_PAR_RESPONSE);
+    clientCallbackParamsMockFn = jest.fn().mockReturnValue({
+      response: ISSUER_CODE_RESPONSE,
+    });
     clientMockFn = jest.fn().mockReturnValue({
       issuer: { authorization_endpoint: ISSUER_AUTH_ENDPOINT },
       requestObject: clientRequestObjectMockFn,
@@ -85,6 +88,7 @@ describe('id-partner', function () {
       refresh: clientRefreshTokenMockFn,
       userinfo: clientFullUserInfoMockFn,
       redirect_uris: [CALLBACK_URI],
+      callbackParams: clientCallbackParamsMockFn,
     });
 
     issuerDiscoverMockFn = jest.fn().mockResolvedValue({ Client: clientMockFn });

--- a/test/idpartner.test.js
+++ b/test/idpartner.test.js
@@ -221,7 +221,7 @@ describe('id-partner', function () {
       expect(clientCallbackMockFn.mock.calls[0]).toEqual([
         CALLBACK_URI,
         { response: ISSUER_CODE_RESPONSE },
-        { jarm: true, state: proofs.state, nonce: proofs.nonce, code_verifier: proofs.codeVerifier },
+        { state: proofs.state, nonce: proofs.nonce, code_verifier: proofs.codeVerifier },
         {}
       ]);
 


### PR DESCRIPTION
## Description
This PR adds support for the new auth method client_secret_basic but preserves the old one private_key_jwt, we modify the registration/update of a client, we modify the provider.js by removing the FAPI compliance, the rp-controller to deal with new callback parameters and with the node-oidc-client to handle both auth methods.

## Roll out plan

1. We need to release idpartner and identity-provider-services, the clients using jwks and private_key_jwt are gonna be ok using the old node-oidc-client 1.3.2,
2. Release node-oidc-client 1.4.0, supporting the client_secret_basic, customers like avvanz and ubs still will have compatibility with private_key_jwt, and they can bump up the node-oidc-client lib to 1.4.0 version

## Test plan

1. We need to do step 1 above and test the sandbox flow
2. Then release the client and test the sandbox flow with the rp bumped to the client 1.4.0 (retro-compatibility)
3. Then create a new client based on client_secret_basic, replace env vars to work with it instead of the old private_key_jwt nd test the sandbox flow

## Sanity Checks
- [] I have added a description to this PR to let people without context review it
- [] I have tested my PR in DEV (demo.idpartner-dev.com, console.idpartner-dev.com) and works as expected
- [] I added/removed/updated ENV vars to any of the public services, I have updated the [trust-platform-example](https://github.com/idpartner-app/trust-platform-example) and I have tested it.
  - <_Link to the PR_>

## Motivation
- https://identity-online.atlassian.net/browse/DEV-867

## Related PRs
- https://github.com/idpartner-app/idpartner/pull/498
- https://github.com/idpartner-app/identity-provider-services/pull/59
