### PR TITLE
DEV-733: Add support for tls_client_ath auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2.1.0
+- Add support for tls_client_auth and keep support for both client_secret_basic (default) and jwt_private_key (legacy)
+
 2.0.0
 - Add support for client-secret and preserve the jwt old usage (bumping up the major version)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-2.1.0
+3.0.0
 - Add support for tls_client_auth and keep support for both client_secret_basic (default) and private_key_jwt (legacy)
 
 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 2.1.0
-- Add support for tls_client_auth and keep support for both client_secret_basic (default) and jwt_private_key (legacy)
+- Add support for tls_client_auth and keep support for both client_secret_basic (default) and private_key_jwt (legacy)
 
 2.0.0
 - Add support for client-secret and preserve the jwt old usage (bumping up the major version)

--- a/docs/example_client_secret_basic.md
+++ b/docs/example_client_secret_basic.md
@@ -1,6 +1,10 @@
-## Example using client_secret_basic auth method
+# Example using client_secret_basic auth method
 
 The usage of `client_secret_basic` is recomended for sandbox apps. If you are implementing a production app please use `tls_cient_auth` instead.
+
+<br>
+
+## Client initialization
 
 ```javascript
 const IDPartner = require('@idpartner/node-oidc-client');

--- a/docs/example_client_secret_basic.md
+++ b/docs/example_client_secret_basic.md
@@ -1,0 +1,88 @@
+## Example using client_secret_basic auth method
+
+The usage of `client_secret_basic` is recomended for sandbox apps. If you are implementing a production app please use `tls_cient_auth` instead.
+
+```javascript
+const IDPartner = require('@idpartner/node-oidc-client');
+
+const idPartner = new IDPartner({
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq', // Your application's client ID
+  client_secret: '3ztRvk4tjDLcTQl6bk3GUJ2KFEkzhBwlCb9gMRaslVilDPLJpCSy6JaXdBLE', // Your application's client secret
+  callback: 'https://myapplication.com/auth/callback', // The location you want the app to return to on success
+  token_endpoint_auth_method: 'client_secret_basic', // The auth method to use
+});
+```
+
+> Instantiating a IDPartner instance without a config object will result in an error
+
+<br>
+
+## Authorization with Synchronous Full User Info
+
+```javascript
+const express = require('express'),
+  router = express.Router(),
+  IDPartner = require('@idpartner/node-oidc-client');
+
+const idPartner = new IDPartner({
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq',
+  client_secret: '3ztRvk4tjDLcTQl6bk3GUJ2KFEkzhBwlCb9gMRaslVilDPLJpCSy6JaXdBLE',
+  callback: 'https://myapplication.com/auth/callback',
+  token_endpoint_auth_method: 'client_secret_basic',
+});
+
+router.get('/auth', (req, res, next) => {
+  const scope = ['openid', 'email', 'profile'];
+  req.session.idp_proofs = idPartner.generateProofs()
+  req.session.issuer = req.query.iss;
+  const authorizationUrl = await idPartner.getAuthorizationUrl(req.query, req.session.idp_proofs, scope);
+  res.redirect(authorizationUrl);
+});
+
+router.get('/auth/callback', (req, res, next) => {
+  const claims = await idPartner.claims(req.query.response, req.session.issuer, req.session.idp_proofs);
+  return res.send(claims);
+  }
+});
+```
+
+<br>
+
+## Authorization with Synchronous Basic User Info and Asynchronous Full User Info
+
+```javascript
+const express = require('express'),
+  router = express.Router(),
+  IDPartner = require('@idpartner/node-oidc-client');
+
+const idPartner = new IDPartner({
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq',
+  client_secret: '3ztRvk4tjDLcTQl6bk3GUJ2KFEkzhBwlCb9gMRaslVilDPLJpCSy6JaXdBLE',
+  callback: 'https://myapplication.com/auth/callback',
+  token_endpoint_auth_method: 'client_secret_basic',
+});
+
+router.get('/auth', (req, res, next) => {
+  // Specify prompt=consent and scope=offline_access to get a refresh token that can be used to fetch full user info later on.
+  const prompt = 'consent';
+  const scope = ['openid', 'email', 'profile', 'offline_access'];
+  req.session.idp_proofs = idPartner.generateProofs()
+  req.session.issuer = req.query.iss;
+  const authorizationUrl = await idPartner.getAuthorizationUrl(req.query, req.session.idp_proofs, scope, prompt);
+  res.redirect(authorizationUrl);
+});
+
+router.get('/auth/callback', (req, res, next) => {
+  const token = await idPartner.token(req.query.response, req.session.issuer, req.session.idp_proofs);
+  const claims = await idPartner.basicUserInfo(req.session.issuer, token)
+  // Refresh token should be encrypted and stored in a secure place. Storing it in session just for demonstration purposes.
+  req.session.refresh_token = token.refresh_token;
+  return res.send(claims);
+});
+
+router.get('/auth/userinfo', (req, res, next) => {
+  const token = await idPartner.refreshToken(req.session.issuer, req.session.refresh_token);
+  const claims = await idPartner.userInfo(req.session.issuer, token)
+  return res.send(claims);
+});
+```

--- a/docs/example_private_key_jwt.md
+++ b/docs/example_private_key_jwt.md
@@ -1,0 +1,120 @@
+## Example using private_key_jwt auth method
+
+The usage of `private_key_jwt` is deprecated and we will stop supporting it soon. If you are already using it please migrate to `tls_client_auth`. If you are implemeting a brand new integration please use `tls_client_auth`.
+
+```javascript
+const IDPartner = require('@idpartner/node-oidc-client');
+
+const rawJWKS = fs.readFileSync('jwks.json');
+const jwks = JSON.parse(rawJWKS);
+const idPartner = new IDPartner({
+  jwks, // Private/public keys used to verify and decrypt any JSON Web Token (JWT) issued by the identity provider authorization server
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq', // Your application's client ID
+  callback: 'https://myapplication.com/auth/callback', // The location you want the app to return to on success
+  token_endpoint_auth_method: 'private_key_jwt', // The auth method to use
+});
+```
+
+**To generate a JWKS you can use [mkjwk.org](mkjwk.org) service to generate a key pair for signing and encryption or use [node-jose](https://github.com/cisco/node-jose) library**
+
+
+For example:
+
+```javascript
+const jose = require('node-jose');
+
+const keyStore = jose.JWK.createKeyStore();
+keyStore.generate('RSA', 2048, { alg: 'RSA-OAEP', enc: 'A256CBC-HS512', use: 'enc' }));
+keyStore.generate('RSA', 2048, { alg: 'PS256', use: 'sig' }));
+const JWKS = keyStore.toJSON(true);
+```
+
+> Instantiating a IDPartner instance without a config object will result in an error
+
+<br>
+
+## Authorization with Synchronous Full User Info
+
+```javascript
+const express = require('express'),
+  router = express.Router(),
+  IDPartner = require('@idpartner/node-oidc-client');
+
+const rawJWKS = fs.readFileSync('jwks.json');
+const jwks = JSON.parse(rawJWKS);
+
+const idPartner = new IDPartner({
+  jwks,
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq',
+  callback: 'https://myapplication.com/auth/callback',
+  token_endpoint_auth_method: 'private_key_jwt',
+});
+
+router.get('/jwks', (req, res, next) => {
+  const jwks = await idPartner.getPublicJWKs();
+  res.send(jwks);
+});
+
+router.get('/auth', (req, res, next) => {
+  const scope = ['openid', 'email', 'profile'];
+  req.session.idp_proofs = idPartner.generateProofs()
+  req.session.issuer = req.query.iss;
+  const authorizationUrl = await idPartner.getAuthorizationUrl(req.query, req.session.idp_proofs, scope);
+  res.redirect(authorizationUrl);
+});
+
+router.get('/auth/callback', (req, res, next) => {
+  const claims = await idPartner.claims(req.query.response, req.session.issuer, req.session.idp_proofs);
+  return res.send(claims);
+  }
+});
+```
+
+<br>
+
+## Authorization with Synchronous Basic User Info and Asynchronous Full User Info
+
+```javascript
+const express = require('express'),
+  router = express.Router(),
+  IDPartner = require('@idpartner/node-oidc-client');
+
+const rawJWKS = fs.readFileSync('jwks.json');
+const jwks = JSON.parse(rawJWKS);
+
+const idPartner = new IDPartner({
+  jwks,
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq',
+  callback: 'https://myapplication.com/auth/callback',
+  token_endpoint_auth_method: 'private_key_jwt',
+});
+
+router.get('/jwks', (req, res, next) => {
+  const jwks = await idPartner.getPublicJWKs();
+  res.send(jwks);
+});
+
+router.get('/auth', (req, res, next) => {
+  // Specify prompt=consent and scope=offline_access to get a refresh token that can be used to fetch full user info later on.
+  const prompt = 'consent';
+  const scope = ['openid', 'email', 'profile', 'offline_access'];
+  req.session.idp_proofs = idPartner.generateProofs()
+  req.session.issuer = req.query.iss;
+  const authorizationUrl = await idPartner.getAuthorizationUrl(req.query, req.session.idp_proofs, scope, prompt);
+  res.redirect(authorizationUrl);
+});
+
+router.get('/auth/callback', (req, res, next) => {
+  const token = await idPartner.token(req.query.response, req.session.issuer, req.session.idp_proofs);
+  const claims = await idPartner.basicUserInfo(req.session.issuer, token)
+  // Refresh token should be encrypted and stored in a secure place. Storing it in session just for demonstration purposes.
+  req.session.refresh_token = token.refresh_token;
+  return res.send(claims);
+});
+
+router.get('/auth/userinfo', (req, res, next) => {
+  const token = await idPartner.refreshToken(req.session.issuer, req.session.refresh_token);
+  const claims = await idPartner.userInfo(req.session.issuer, token)
+  return res.send(claims);
+});
+```

--- a/docs/example_private_key_jwt.md
+++ b/docs/example_private_key_jwt.md
@@ -1,6 +1,10 @@
-## Example using private_key_jwt auth method
+# Example using private_key_jwt auth method
 
 The usage of `private_key_jwt` is deprecated and we will stop supporting it soon. If you are already using it please migrate to `tls_client_auth`. If you are implemeting a brand new integration please use `tls_client_auth`.
+
+<br>
+
+## Client initialization
 
 ```javascript
 const IDPartner = require('@idpartner/node-oidc-client');

--- a/docs/example_tls_client_auth_with_jwks.md
+++ b/docs/example_tls_client_auth_with_jwks.md
@@ -1,0 +1,131 @@
+## Example using tls_client_auth auth method with JWKs
+
+The usage of `tls_client_auth` is required for production apps. 
+
+The use of JWKs is optional for out `tls_client_auth` integration. While it enhances the security of the integration it also increases the level of difficuly to integrate a production app. If you do not need JWKs configured see [Example using tls_client_auth without JWKs](./example_tls_client_auth_without_jwks.md)
+
+```javascript
+const IDPartner = require('@idpartner/node-oidc-client');
+
+const rawJWKS = fs.readFileSync('jwks.json');
+const jwks = JSON.parse(rawJWKS);
+
+const idPartner = new IDPartner({
+  jwks, // Private/public keys used to verify and decrypt any JSON Web Token (JWT) issued by the identity provider authorization server
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq', // Your application's client ID
+  callback: 'https://myapplication.com/auth/callback', // The location you want the app to return to on success
+  token_endpoint_auth_method: 'tls_client_auth', // The auth method to use
+  tls_client_cert: fs.readFileSync('tls-client-cert.pem'), // The cert issued by IDPartner
+  tls_client_key: fs.readFileSync('tls-client-key.key'), // They private key owned by you
+});
+```
+
+**To have IDPartner to issue a certificate contact us at help@idpartner.com**
+
+**To generate a JWKS you can use [mkjwk.org](mkjwk.org) service to generate a key pair for signing and encryption or use [node-jose](https://github.com/cisco/node-jose) library**
+
+
+For example:
+
+```javascript
+const jose = require('node-jose');
+
+const keyStore = jose.JWK.createKeyStore();
+keyStore.generate('RSA', 2048, { alg: 'RSA-OAEP', enc: 'A256CBC-HS512', use: 'enc' }));
+keyStore.generate('RSA', 2048, { alg: 'PS256', use: 'sig' }));
+const JWKS = keyStore.toJSON(true);
+```
+
+> Instantiating a IDPartner instance without a config object will result in an error
+
+<br>
+
+## Authorization with Synchronous Full User Info
+
+```javascript
+const express = require('express'),
+  router = express.Router(),
+  IDPartner = require('@idpartner/node-oidc-client');
+
+const rawJWKS = fs.readFileSync('jwks.json');
+const jwks = JSON.parse(rawJWKS);
+
+const idPartner = new IDPartner({
+  jwks,
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq',
+  callback: 'https://myapplication.com/auth/callback',
+  token_endpoint_auth_method: 'tls_client_auth',
+  tls_client_cert: fs.readFileSync('tls-client-cert.pem'),
+  tls_client_key: fs.readFileSync('tls-client-key.key'), 
+});
+
+router.get('/jwks', (req, res, next) => {
+  const jwks = await idPartner.getPublicJWKs();
+  res.send(jwks);
+});
+
+router.get('/auth', (req, res, next) => {
+  const scope = ['openid', 'email', 'profile'];
+  req.session.idp_proofs = idPartner.generateProofs()
+  req.session.issuer = req.query.iss;
+  const authorizationUrl = await idPartner.getAuthorizationUrl(req.query, req.session.idp_proofs, scope);
+  res.redirect(authorizationUrl);
+});
+
+router.get('/auth/callback', (req, res, next) => {
+  const claims = await idPartner.claims(req.query.response, req.session.issuer, req.session.idp_proofs);
+  return res.send(claims);
+  }
+});
+```
+
+<br>
+
+## Authorization with Synchronous Basic User Info and Asynchronous Full User Info
+
+```javascript
+const express = require('express'),
+  router = express.Router(),
+  IDPartner = require('@idpartner/node-oidc-client');
+
+const rawJWKS = fs.readFileSync('jwks.json');
+const jwks = JSON.parse(rawJWKS);
+
+const idPartner = new IDPartner({
+  jwks,
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq',
+  callback: 'https://myapplication.com/auth/callback',
+  token_endpoint_auth_method: 'tls_client_auth',
+  tls_client_cert: fs.readFileSync('tls-client-cert.pem'),
+  tls_client_key: fs.readFileSync('tls-client-key.key'), 
+});
+
+router.get('/jwks', (req, res, next) => {
+  const jwks = await idPartner.getPublicJWKs();
+  res.send(jwks);
+});
+
+router.get('/auth', (req, res, next) => {
+  // Specify prompt=consent and scope=offline_access to get a refresh token that can be used to fetch full user info later on.
+  const prompt = 'consent';
+  const scope = ['openid', 'email', 'profile', 'offline_access'];
+  req.session.idp_proofs = idPartner.generateProofs()
+  req.session.issuer = req.query.iss;
+  const authorizationUrl = await idPartner.getAuthorizationUrl(req.query, req.session.idp_proofs, scope, prompt);
+  res.redirect(authorizationUrl);
+});
+
+router.get('/auth/callback', (req, res, next) => {
+  const token = await idPartner.token(req.query.response, req.session.issuer, req.session.idp_proofs);
+  const claims = await idPartner.basicUserInfo(req.session.issuer, token)
+  // Refresh token should be encrypted and stored in a secure place. Storing it in session just for demonstration purposes.
+  req.session.refresh_token = token.refresh_token;
+  return res.send(claims);
+});
+
+router.get('/auth/userinfo', (req, res, next) => {
+  const token = await idPartner.refreshToken(req.session.issuer, req.session.refresh_token);
+  const claims = await idPartner.userInfo(req.session.issuer, token)
+  return res.send(claims);
+});
+```

--- a/docs/example_tls_client_auth_with_jwks.md
+++ b/docs/example_tls_client_auth_with_jwks.md
@@ -1,8 +1,12 @@
-## Example using tls_client_auth auth method with JWKs
+# Example using tls_client_auth auth method with JWKs
 
 The usage of `tls_client_auth` is required for production apps. 
 
 The use of JWKs is optional for out `tls_client_auth` integration. While it enhances the security of the integration it also increases the level of difficuly to integrate a production app. If you do not need JWKs configured see [Example using tls_client_auth without JWKs](./example_tls_client_auth_without_jwks.md)
+
+<br>
+
+## Client initialization
 
 ```javascript
 const IDPartner = require('@idpartner/node-oidc-client');

--- a/docs/example_tls_client_auth_without_jwks.md
+++ b/docs/example_tls_client_auth_without_jwks.md
@@ -1,8 +1,12 @@
-## Example using tls_client_auth auth method with JWKs
+# Example using tls_client_auth auth method with JWKs
 
 The usage of `tls_client_auth` is required for production apps. 
 
 If you need to implement JWKs (which are optional for our integration) see [Example using tls_client_auth with JWKS](./example_tls_client_auth_with_jwks.md).
+
+<br>
+
+## Client initialization
 
 ```javascript
 const IDPartner = require('@idpartner/node-oidc-client');

--- a/docs/example_tls_client_auth_without_jwks.md
+++ b/docs/example_tls_client_auth_without_jwks.md
@@ -1,0 +1,95 @@
+## Example using tls_client_auth auth method with JWKs
+
+The usage of `tls_client_auth` is required for production apps. 
+
+If you need to implement JWKs (which are optional for our integration) see [Example using tls_client_auth with JWKS](./example_tls_client_auth_with_jwks.md).
+
+```javascript
+const IDPartner = require('@idpartner/node-oidc-client');
+
+const idPartner = new IDPartner({
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq', // Your application's client ID
+  callback: 'https://myapplication.com/auth/callback', // The location you want the app to return to on success
+  token_endpoint_auth_method: 'tls_client_auth', // The auth method to use
+  tls_client_cert: fs.readFileSync('tls-client-cert.pem'), // The cert issued by IDPartner
+  tls_client_key: fs.readFileSync('tls-client-key.key'), // They private key owned by you
+});
+```
+
+**To have IDPartner to issue a certificate contact us at help@idpartner.com**
+
+> Instantiating a IDPartner instance without a config object will result in an error
+
+<br>
+
+## Authorization with Synchronous Full User Info
+
+```javascript
+const express = require('express'),
+  router = express.Router(),
+  IDPartner = require('@idpartner/node-oidc-client');
+
+const idPartner = new IDPartner({
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq',
+  callback: 'https://myapplication.com/auth/callback',
+  token_endpoint_auth_method: 'tls_client_auth',
+  tls_client_cert: fs.readFileSync('tls-client-cert.pem'),
+  tls_client_key: fs.readFileSync('tls-client-key.key'), 
+});
+
+router.get('/auth', (req, res, next) => {
+  const scope = ['openid', 'email', 'profile'];
+  req.session.idp_proofs = idPartner.generateProofs()
+  req.session.issuer = req.query.iss;
+  const authorizationUrl = await idPartner.getAuthorizationUrl(req.query, req.session.idp_proofs, scope);
+  res.redirect(authorizationUrl);
+});
+
+router.get('/auth/callback', (req, res, next) => {
+  const claims = await idPartner.claims(req.query.response, req.session.issuer, req.session.idp_proofs);
+  return res.send(claims);
+  }
+});
+```
+
+<br>
+
+## Authorization with Synchronous Basic User Info and Asynchronous Full User Info
+
+```javascript
+const express = require('express'),
+  router = express.Router(),
+  IDPartner = require('@idpartner/node-oidc-client');
+
+const idPartner = new IDPartner({
+  client_id: 'mXzJ0TJEbWQb2A8s1z6gq',
+  callback: 'https://myapplication.com/auth/callback',
+  token_endpoint_auth_method: 'tls_client_auth',
+  tls_client_cert: fs.readFileSync('tls-client-cert.pem'),
+  tls_client_key: fs.readFileSync('tls-client-key.key'), 
+});
+
+router.get('/auth', (req, res, next) => {
+  // Specify prompt=consent and scope=offline_access to get a refresh token that can be used to fetch full user info later on.
+  const prompt = 'consent';
+  const scope = ['openid', 'email', 'profile', 'offline_access'];
+  req.session.idp_proofs = idPartner.generateProofs()
+  req.session.issuer = req.query.iss;
+  const authorizationUrl = await idPartner.getAuthorizationUrl(req.query, req.session.idp_proofs, scope, prompt);
+  res.redirect(authorizationUrl);
+});
+
+router.get('/auth/callback', (req, res, next) => {
+  const token = await idPartner.token(req.query.response, req.session.issuer, req.session.idp_proofs);
+  const claims = await idPartner.basicUserInfo(req.session.issuer, token)
+  // Refresh token should be encrypted and stored in a secure place. Storing it in session just for demonstration purposes.
+  req.session.refresh_token = token.refresh_token;
+  return res.send(claims);
+});
+
+router.get('/auth/userinfo', (req, res, next) => {
+  const token = await idPartner.refreshToken(req.session.issuer, req.session.refresh_token);
+  const claims = await idPartner.userInfo(req.session.issuer, token)
+  return res.send(claims);
+});
+```

--- a/docs/example_tls_client_auth_without_jwks.md
+++ b/docs/example_tls_client_auth_without_jwks.md
@@ -1,4 +1,4 @@
-# Example using tls_client_auth auth method with JWKs
+# Example using tls_client_auth auth method without JWKs
 
 The usage of `tls_client_auth` is required for production apps. 
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -41,7 +41,7 @@ const getClientConfig = config => {
   if (config.token_endpoint_auth_method === 'tls_client_auth') {
     clientConfig = {
       ...clientConfig,
-      tls_client_certificate_bound_access_tokens: config.mtls_client_certificate_bound_access_tokem,
+      tls_client_certificate_bound_access_tokens: config.tls_client_certificate_bound_access_token,
     }
   }
 
@@ -58,13 +58,13 @@ const createClient = async (config, issuer) => {
 
   if (config.token_endpoint_auth_method === 'tls_client_auth') {
     client[custom.http_options] = (url, _options) => {
-      const serverCA = config.mtls_server_ca ? { ca: config.mtls_server_ca } : {};
+      const serverCA = config.tls_server_ca ? { ca: config.tls_server_ca } : {};
 
       return {
         ...url,
         ...serverCA,
-        cert: config.mtls_client_cert,
-        key: config.mtls_client_key,
+        cert: config.tls_client_cert,
+        key: config.tls_client_key,
       };
     };
   }
@@ -84,10 +84,10 @@ class IDPartner {
       token_endpoint_auth_method: 'client_secret_basic',
 
       // tls_client_auth auth method config
-      mtls_server_ca: null,
-      mtls_client_cert: null,
-      mtls_client_key: null,
-      mtls_client_certificate_bound_access_token: true,
+      tls_server_ca: null,
+      tls_client_cert: null,
+      tls_client_key: null,
+      tls_client_certificate_bound_access_token: true,
     };
 
     this.config = {
@@ -95,7 +95,7 @@ class IDPartner {
       ...config,
     };
 
-    if (!SUPPORTED_AUTH_METHODS.includes(config.token_endpoint_auth_method)) {
+    if (!SUPPORTED_AUTH_METHODS.includes(this.config.token_endpoint_auth_method)) {
       throw new Error(`Unsupported token_endpoint_auth_method '${config.token_endpoint_auth_method}'. It must be one of (${SUPPORTED_AUTH_METHODS.join(', ')})`)
     }
   }

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -19,17 +19,9 @@ const DEFAULT_TIMEOUT_IN_MILLIS = 3500;
 const createHttpClient = iss => HTTPClient({ baseURL: iss, logger });;
 
 const getClientConfig = config => {
-  let clientConfig = {
-    client_id: config.client_id,
-    token_endpoint_auth_method: config.token_endpoint_auth_method,
-    redirect_uris: config.callback.split(','),
-    authorization_signed_response_alg: SIGNING_ALG,
-    id_token_signed_response_alg: SIGNING_ALG,
-  };
-
+  let jwksConfig = {};
   if (config.jwks) {
-    clientConfig = {
-      ...clientConfig,
+    jwksConfig = {
       authorization_encrypted_response_alg: ENCRYPTION_ALG,
       authorization_encrypted_response_enc: ENCRYPTION_ENC,
       id_token_encrypted_response_alg: ENCRYPTION_ALG,
@@ -38,14 +30,22 @@ const getClientConfig = config => {
     };
   }
 
+  let tlsConfig = {};
   if (config.token_endpoint_auth_method === 'tls_client_auth') {
-    clientConfig = {
-      ...clientConfig,
+    tlsConfig = {
       tls_client_certificate_bound_access_tokens: config.tls_client_certificate_bound_access_token,
-    }
+    };
   }
 
-  return clientConfig;
+  return {
+    client_id: config.client_id,
+    token_endpoint_auth_method: config.token_endpoint_auth_method,
+    redirect_uris: config.callback.split(','),
+    authorization_signed_response_alg: SIGNING_ALG,
+    id_token_signed_response_alg: SIGNING_ALG,
+    ...jwksConfig,
+    ...tlsConfig,
+  };
 };
 
 const createClient = async (config, issuer) => {

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -5,63 +5,85 @@ const jose = require('node-jose');
 const { HTTPClient } = require('@idpartner/http-client');
 const { logger } = require('@idpartner/logger');
 
+SUPPORTED_AUTH_METHODS = [
+  'client_secret_basic',
+  'tls_client_auth',
+  'private_key_jwt', // For backward compatibility
+];
+
 const SIGNING_ALG = 'PS256';
 const ENCRYPTION_ALG = 'RSA-OAEP';
 const ENCRYPTION_ENC = 'A256CBC-HS512';
 const DEFAULT_TIMEOUT_IN_MILLIS = 3500;
 
-const createClient = async (config, issuer) => {
-  const clientId = config.client_id;
-  const redirectUri = config.callback;
-  const jwks = config.jwks;
+const createHttpClient = iss => HTTPClient({ baseURL: iss, logger });;
 
+const getClientConfig = config => {
+  let clientConfig = {
+    client_id: config.client_id,
+    token_endpoint_auth_method: config.token_endpoint_auth_method,
+    redirect_uris: config.callback.split(','),
+    authorization_signed_response_alg: SIGNING_ALG,
+    id_token_signed_response_alg: SIGNING_ALG,
+  };
+
+  if (config.jwks) {
+    clientConfig = {
+      ...clientConfig,
+      authorization_encrypted_response_alg: ENCRYPTION_ALG,
+      authorization_encrypted_response_enc: ENCRYPTION_ENC,
+      id_token_encrypted_response_alg: ENCRYPTION_ALG,
+      id_token_encrypted_response_enc: ENCRYPTION_ENC,
+      request_object_signing_alg: SIGNING_ALG,
+    };
+  }
+
+  if (config.token_endpoint_auth_method === 'tls_client_auth') {
+    clientConfig = {
+      ...clientConfig,
+      tls_client_certificate_bound_access_tokens: config.mtls_client_certificate_bound_access_tokem,
+    }
+  }
+
+  return clientConfig;
+};
+
+const createClient = async (config, issuer) => {
   custom.setHttpOptionsDefaults({
     timeout: parseInt(config.timeout) || DEFAULT_TIMEOUT_IN_MILLIS,
   });
 
-  if (config.mtls_enabled) {
+  const clientConfig = getClientConfig(config);
+  const client = new issuer.Client(clientConfig, config.jwks);
+
+  if (config.token_endpoint_auth_method === 'tls_client_auth') {
     client[custom.http_options] = (url, _options) => {
-      // Specify the server CA only if we are connecting to a server with a self-signed cert
-      const serverCAData = config.mtls_server_ca ? { ca: mtls_server_ca } : {};
+      const serverCA = config.mtls_server_ca ? { ca: config.mtls_server_ca } : {};
 
       return {
         ...url,
-        ...serverCAData,
+        ...serverCA,
         cert: config.mtls_client_cert,
         key: config.mtls_client_key,
       };
     };
   }
 
-  const client = new issuer.Client(
-    {
-      client_id: clientId,
-      token_endpoint_auth_method: config.token_endpoint_auth_method,
-      redirect_uris: redirectUri.split(','),
-      authorization_signed_response_alg: SIGNING_ALG,
-      // authorization_encrypted_response_alg: ENCRYPTION_ALG,
-      // authorization_encrypted_response_enc: ENCRYPTION_ENC,
-      id_token_signed_response_alg: SIGNING_ALG,
-      // id_token_encrypted_response_alg: ENCRYPTION_ALG,
-      // id_token_encrypted_response_enc: ENCRYPTION_ENC,
-      // request_object_signing_alg: SIGNING_ALG,
-      tls_client_certificate_bound_access_tokens: config.mtls_client_certificate_bound_access_token
-    },
-    jwks,
-  );
+  return client;
 };
-
-const createHttpClient = iss => HTTPClient({ baseURL: iss, logger });;
 
 class IDPartner {
   constructor(config) {
     if (!config) {
       throw new Error('Config missing. The config object is required to make any call to the ' + 'IDPartner API');
     }
+
     const defaultConfig = {
+      // generic config
       account_selector_service_url: 'https://auth-api.idpartner.com/oidc-proxy',
       token_endpoint_auth_method: 'client_secret_basic',
-      mtls_enabled: false,
+
+      // tls_client_auth auth method config
       mtls_server_ca: null,
       mtls_client_cert: null,
       mtls_client_key: null,
@@ -72,6 +94,10 @@ class IDPartner {
       ...defaultConfig,
       ...config,
     };
+
+    if (!SUPPORTED_AUTH_METHODS.includes(config.token_endpoint_auth_method)) {
+      throw new Error(`Unsupported token_endpoint_auth_method '${config.token_endpoint_auth_method}'. It must be one of (${SUPPORTED_AUTH_METHODS.join(', ')})`)
+    }
   }
 
   async #getClient(expectedIssuer) {
@@ -111,9 +137,8 @@ class IDPartner {
 
     const { state, nonce, codeVerifier } = proofs;
     const codeChallenge = generators.codeChallenge(codeVerifier);
-
     const client = await this.#getClient(iss);
-    const requestObject = await client.requestObject({
+    const authorizationParams = {
       redirect_uri: redirectUri,
       code_challenge_method: 'S256',
       code_challenge: codeChallenge,
@@ -128,9 +153,15 @@ class IDPartner {
       'x-fapi-interaction-id': uuidv4(),
       identity_provider_id: query.idp_id,
       idpartner_token: idpartnerToken,
-    });
+    };
 
-    const { request_uri } = await client.pushedAuthorizationRequest({ request: requestObject });
+    let pushedAuthorizationRequestParams = authorizationParams;
+    if (this.config.jwks) {
+      // Generate a request object if jwks are configured
+      pushedAuthorizationRequestParams = { request: await client.requestObject(authorizationParams) };
+    }
+
+    const { request_uri } = await client.pushedAuthorizationRequest(pushedAuthorizationRequestParams);
     const queryParams = new URLSearchParams({ request_uri });
     return `${client.issuer.authorization_endpoint}?${queryParams}`;
   }

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -108,7 +108,7 @@ class IDPartner {
     };
 
     if (!SUPPORTED_AUTH_METHODS.includes(this.config.token_endpoint_auth_method)) {
-      throw new Error(`Unsupported token_endpoint_auth_method '${config.token_endpoint_auth_method}'. It must be one of (${SUPPORTED_AUTH_METHODS.join(', ')})`)
+      throw new Error(`Unsupported token_endpoint_auth_method '${config.token_endpoint_auth_method}'. It must be one of (${SUPPORTED_AUTH_METHODS.join(', ')})`);
     }
   }
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -90,14 +90,15 @@ class IDPartner {
       // generic config
       account_selector_service_url: 'https://auth-api.idpartner.com/oidc-proxy',
       token_endpoint_auth_method: 'client_secret_basic',
+      jwks: undefined,
 
       // client_secret_basic auth method config
-      client_secret: null,
+      client_secret: undefined,
 
       // tls_client_auth auth method config
-      tls_server_ca: null,
-      tls_client_cert: null,
-      tls_client_key: null,
+      tls_server_ca: undefined,
+      tls_client_cert: undefined,
+      tls_client_key: undefined,
       tls_client_certificate_bound_access_token: true,
     };
 
@@ -122,6 +123,10 @@ class IDPartner {
   };
 
   async getPublicJWKs() {
+    if (!this.config.jwks) {
+      return {};
+    }
+
     const keystore = await jose.JWK.asKeyStore(this.config.jwks);
     return keystore.toJSON(false);
   }
@@ -133,7 +138,6 @@ class IDPartner {
   async getAuthorizationUrl(query, proofs, scope, prompt) {
     const {
       client_id: clientId,
-      client_secret: clientSecret,
       account_selector_service_url: accountSelectorServiceUrl,
       callback: redirectUri
     } = this.config;

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -14,22 +14,38 @@ const createClient = async (config, issuer) => {
   const clientId = config.client_id;
   const redirectUri = config.callback;
   const jwks = config.jwks;
+
   custom.setHttpOptionsDefaults({
     timeout: parseInt(config.timeout) || DEFAULT_TIMEOUT_IN_MILLIS,
   });
 
-  return new issuer.Client(
+  if (config.mtls_enabled) {
+    client[custom.http_options] = (url, _options) => {
+      // Specify the server CA only if we are connecting to a server with a self-signed cert
+      const serverCAData = config.mtls_server_ca ? { ca: mtls_server_ca } : {};
+
+      return {
+        ...url,
+        ...serverCAData,
+        cert: config.mtls_client_cert,
+        key: config.mtls_client_key,
+      };
+    };
+  }
+
+  const client = new issuer.Client(
     {
       client_id: clientId,
-      token_endpoint_auth_method: 'private_key_jwt',
+      token_endpoint_auth_method: config.token_endpoint_auth_method,
       redirect_uris: redirectUri.split(','),
       authorization_signed_response_alg: SIGNING_ALG,
-      authorization_encrypted_response_alg: ENCRYPTION_ALG,
-      authorization_encrypted_response_enc: ENCRYPTION_ENC,
+      // authorization_encrypted_response_alg: ENCRYPTION_ALG,
+      // authorization_encrypted_response_enc: ENCRYPTION_ENC,
       id_token_signed_response_alg: SIGNING_ALG,
-      id_token_encrypted_response_alg: ENCRYPTION_ALG,
-      id_token_encrypted_response_enc: ENCRYPTION_ENC,
-      request_object_signing_alg: SIGNING_ALG,
+      // id_token_encrypted_response_alg: ENCRYPTION_ALG,
+      // id_token_encrypted_response_enc: ENCRYPTION_ENC,
+      // request_object_signing_alg: SIGNING_ALG,
+      tls_client_certificate_bound_access_tokens: config.mtls_client_certificate_bound_access_token
     },
     jwks,
   );
@@ -44,7 +60,12 @@ class IDPartner {
     }
     const defaultConfig = {
       account_selector_service_url: 'https://auth-api.idpartner.com/oidc-proxy',
-      apiVersion: 'v1',
+      token_endpoint_auth_method: 'client_secret_basic',
+      mtls_enabled: false,
+      mtls_server_ca: null,
+      mtls_client_cert: null,
+      mtls_client_key: null,
+      mtls_client_certificate_bound_access_token: true,
     };
 
     this.config = {
@@ -58,7 +79,7 @@ class IDPartner {
     return createClient(this.config, issuer);
   }
 
-  async #getAccessToken(client, codeResponse, { state, nonce, codeVerifier }, options={}) {
+  async #getAccessToken(client, codeResponse, { state, nonce, codeVerifier }, options = {}) {
     const params = { response: codeResponse };
     return client.callback(client.redirect_uris[0], params, { jarm: true, state, nonce, code_verifier: codeVerifier }, options);
   };
@@ -117,23 +138,23 @@ class IDPartner {
   // Legacy function to fetch the user info using the authorization code. This is an optimization of the more verbose version
   // that requires to first call the `token `function to get the access token and then call the `userInfo` function to get the
   // user info claims. Use this if you need to fetch the user info right after the access token is returned.
-  async claims(codeResponse, expectedIssuer, proofs, options={}) {
+  async claims(codeResponse, expectedIssuer, proofs, options = {}) {
     const client = await this.#getClient(expectedIssuer);
     const accessToken = await this.#getAccessToken(client, codeResponse, proofs, options);
     return client.userinfo(accessToken, options);
   }
 
-  async token(codeResponse, expectedIssuer, proofs, options={}) {
+  async token(codeResponse, expectedIssuer, proofs, options = {}) {
     const client = await this.#getClient(expectedIssuer);
     return this.#getAccessToken(client, codeResponse, proofs, options);
   }
 
-  async refreshToken(expectedIssuer, refreshToken, options={}) {
+  async refreshToken(expectedIssuer, refreshToken, options = {}) {
     const client = await this.#getClient(expectedIssuer);
     return client.refresh(refreshToken, options);
   }
 
-  async userInfo(expectedIssuer, accessToken, options={}) {
+  async userInfo(expectedIssuer, accessToken, options = {}) {
     const client = await this.#getClient(expectedIssuer);
     return client.userinfo(accessToken, options);
   }
@@ -141,11 +162,11 @@ class IDPartner {
   // The unused params below were added to a) be consistent with the interface exposed by the
   // `userInfo` function, and, b) to be able to modify the underlying implementation to make
   // make a request to the OP without changing the interface of the function.
-  async basicUserInfo(_expectedIssuer, accessToken, _options={}) {
+  async basicUserInfo(_expectedIssuer, accessToken, _options = {}) {
     return accessToken.claims();
   }
 
-  async paymentDetailsInfo(expectedIssuer, accessToken, options={}) {
+  async paymentDetailsInfo(expectedIssuer, accessToken, options = {}) {
     const client = await this.#getClient(expectedIssuer);
 
     const response = await client.requestResource(client.issuer.payment_details_info_endpoint, accessToken, options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {

--- a/test/idpartner.test.js
+++ b/test/idpartner.test.js
@@ -68,6 +68,7 @@ describe('id-partner', function () {
     client_id: CLIENT_ID,
     callback: CALLBACK_URI,
     account_selector_service_url: ACCOUNT_SELECTOR,
+    token_endpoint_auth_method: 'private_key_jwt',
   });
 
   beforeEach(() => {


### PR DESCRIPTION
Add support for `tls_client_auth` auth method.

Additionally, update logic to support JWKs regardless of the auth method that the client is using. We have tested the following scenarios and they are all working.
- private_key_jwt + jwks (backward compatibility)
- tls_client_auth + no jwks
- tls_client_auth + jwks
- client_secret_basic + no jwks
- client_secret_basic + jwks

The `client_secret_basic` auth method is used by default. If clients need to implement either `private_key_jwt` or `tls_client_auth` the prop `token_endpoint_auth_method` should be sent as part of the IDPartner client config.