### PR TITLE
Re-stablish old behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-1.4.0
-
-- Add support for client-secret and preserve the jwt old usage
-
 1.3.2
 - Not use default response in payments_details endpoint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.5.0
+
+- Revert of https://github.com/idpartner-app/node-oidc-client/pull/18
+
+1.4.0
+- Add support for client-secret and preserve the jwt old usage
+
 1.3.2
 - Not use default response in payments_details endpoint
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -12,38 +12,27 @@ const DEFAULT_TIMEOUT_IN_MILLIS = 3500;
 
 const createClient = async (config, issuer) => {
   const clientId = config.client_id;
-  const clientSecret = config.client_secret;
   const redirectUri = config.callback;
   const jwks = config.jwks;
   custom.setHttpOptionsDefaults({
     timeout: parseInt(config.timeout) || DEFAULT_TIMEOUT_IN_MILLIS,
   });
 
-  if (clientSecret) {
-    return new issuer.Client({
+  return new issuer.Client(
+    {
       client_id: clientId,
-      client_secret: clientSecret,
+      token_endpoint_auth_method: 'private_key_jwt',
       redirect_uris: redirectUri.split(','),
-      id_token_signed_response_alg: SIGNING_ALG,
       authorization_signed_response_alg: SIGNING_ALG,
-    });
-  } else {
-    return new issuer.Client(
-      {
-        client_id: clientId,
-        token_endpoint_auth_method: 'private_key_jwt',
-        redirect_uris: redirectUri.split(','),
-        authorization_signed_response_alg: SIGNING_ALG,
-        authorization_encrypted_response_alg: ENCRYPTION_ALG,
-        authorization_encrypted_response_enc: ENCRYPTION_ENC,
-        id_token_signed_response_alg: SIGNING_ALG,
-        id_token_encrypted_response_alg: ENCRYPTION_ALG,
-        id_token_encrypted_response_enc: ENCRYPTION_ENC,
-        request_object_signing_alg: SIGNING_ALG,
-      },
-      jwks,
-    );
-  }
+      authorization_encrypted_response_alg: ENCRYPTION_ALG,
+      authorization_encrypted_response_enc: ENCRYPTION_ENC,
+      id_token_signed_response_alg: SIGNING_ALG,
+      id_token_encrypted_response_alg: ENCRYPTION_ALG,
+      id_token_encrypted_response_enc: ENCRYPTION_ENC,
+      request_object_signing_alg: SIGNING_ALG,
+    },
+    jwks,
+  );
 };
 
 const createHttpClient = iss => HTTPClient({ baseURL: iss, logger });;
@@ -70,8 +59,8 @@ class IDPartner {
   }
 
   async #getAccessToken(client, codeResponse, { state, nonce, codeVerifier }, options={}) {
-    const params = client.callbackParams(codeResponse);
-    return client.callback(client.redirect_uris[0], params, { state, nonce, code_verifier: codeVerifier }, options);
+    const params = { response: codeResponse };
+    return client.callback(client.redirect_uris[0], params, { jarm: true, state, nonce, code_verifier: codeVerifier }, options);
   };
 
   async getPublicJWKs() {
@@ -86,7 +75,6 @@ class IDPartner {
   async getAuthorizationUrl(query, proofs, scope, prompt) {
     const {
       client_id: clientId,
-      client_secret: clientSecret,
       account_selector_service_url: accountSelectorServiceUrl,
       callback: redirectUri
     } = this.config;
@@ -102,10 +90,9 @@ class IDPartner {
 
     const { state, nonce, codeVerifier } = proofs;
     const codeChallenge = generators.codeChallenge(codeVerifier);
-    const client = await this.#getClient(iss);
-    let response;
 
-    const params = {
+    const client = await this.#getClient(iss);
+    const requestObject = await client.requestObject({
       redirect_uri: redirectUri,
       code_challenge_method: 'S256',
       code_challenge: codeChallenge,
@@ -113,23 +100,16 @@ class IDPartner {
       nonce,
       scope: scope.join(' '),
       prompt,
+      response_mode: 'jwt',
       response_type: 'code',
       client_id: clientId,
       nbf: Math.floor(new Date().getTime() / 1000),
       'x-fapi-interaction-id': uuidv4(),
       identity_provider_id: query.idp_id,
       idpartner_token: idpartnerToken,
-    };
-    if (clientSecret) {
-      params.client_secret = clientSecret;
-      response = await client.pushedAuthorizationRequest(params);
-    } else {
-      params.response_mode = 'jwt';
-      const requestObject = await client.requestObject(params);
-      response = await client.pushedAuthorizationRequest({ request: requestObject });
-    }
-    const { request_uri } = response;
+    });
 
+    const { request_uri } = await client.pushedAuthorizationRequest({ request: requestObject });
     const queryParams = new URLSearchParams({ request_uri });
     return `${client.issuer.authorization_endpoint}?${queryParams}`;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "1.3.2",
+  "version": "1.5.0",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "1.4.0",
+  "version": "1.3.2",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {

--- a/test/idpartner.test.js
+++ b/test/idpartner.test.js
@@ -77,9 +77,6 @@ describe('id-partner', function () {
     clientFullUserInfoMockFn = jest.fn().mockReturnValue(ISSUER_FULL_USERINFO_RESPONSE);
     clientRequestObjectMockFn = jest.fn().mockReturnValue(ISSUER_REQUEST_OBJECT);
     clientPushedAuthRequestMockFn = jest.fn().mockReturnValue(ISSUER_PAR_RESPONSE);
-    clientCallbackParamsMockFn = jest.fn().mockReturnValue({
-      response: ISSUER_CODE_RESPONSE,
-    });
     clientMockFn = jest.fn().mockReturnValue({
       issuer: { authorization_endpoint: ISSUER_AUTH_ENDPOINT },
       requestObject: clientRequestObjectMockFn,
@@ -88,7 +85,6 @@ describe('id-partner', function () {
       refresh: clientRefreshTokenMockFn,
       userinfo: clientFullUserInfoMockFn,
       redirect_uris: [CALLBACK_URI],
-      callbackParams: clientCallbackParamsMockFn,
     });
 
     issuerDiscoverMockFn = jest.fn().mockResolvedValue({ Client: clientMockFn });
@@ -225,7 +221,7 @@ describe('id-partner', function () {
       expect(clientCallbackMockFn.mock.calls[0]).toEqual([
         CALLBACK_URI,
         { response: ISSUER_CODE_RESPONSE },
-        { state: proofs.state, nonce: proofs.nonce, code_verifier: proofs.codeVerifier },
+        { jarm: true, state: proofs.state, nonce: proofs.nonce, code_verifier: proofs.codeVerifier },
         {}
       ]);
 


### PR DESCRIPTION
Reverts idpartner-app/node-oidc-client#18

we are reverting to prevent any client from automatically getting the new version due to the usage of ^symbol in the package json.

the plan is to release a new minor with old behavior and then revert the revert to include the new behavior with a major version only acquirable manually