### PR TITLE
DEV-733: Remove tls_client_certificate_bound_access_tokens from default confg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+3.0.2
+- remove tls_client_certificate_bound_access_token from the default config. Force it to true for tls_client_auth auth methods
+
 3.0.1
 - Add tls_client_auth for payment details endpoint
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -29,7 +29,7 @@ const getClientConfig = config => {
   let tlsConfig = {};
   if (config.token_endpoint_auth_method === 'tls_client_auth') {
     tlsConfig = {
-      tls_client_certificate_bound_access_tokens: config.tls_client_certificate_bound_access_token,
+      tls_client_certificate_bound_access_tokens: true,
     };
   }
 
@@ -99,7 +99,6 @@ class IDPartner {
       tls_server_ca: undefined,
       tls_client_cert: undefined,
       tls_client_key: undefined,
-      tls_client_certificate_bound_access_token: true,
     };
 
     this.config = {
@@ -215,7 +214,7 @@ class IDPartner {
 
   async paymentDetailsInfo(expectedIssuer, accessToken, options = {}) {
     const client = await this.#getClient(expectedIssuer);
-    const mTLS = !!this.config.tls_client_certificate_bound_access_token;
+    const mTLS = !!client.tls_client_certificate_bound_access_tokens;
 
     let targetURL = client.issuer.payment_details_info_endpoint;
     if (mTLS && client.issuer.mtls_endpoint_aliases) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {


### PR DESCRIPTION
Remove `tls_client_certificate_bound_access_tokens` from the default config. Always set it to true when the `token_endpoint_auth_method` is set to `tls_client_auth`