### PR TITLE
[DEV-953] Add claims parameter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+3.0.5
+- Add claims parameter support
+
 3.0.4
 - Bump up openid-client lib
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -138,35 +138,37 @@ class IDPartner {
   }
 
   async #getScopesFromClaims(claimsObject) {
-    // this map comes from core-services/oidc-provider-service/src/services/express/provider.js:50-66
-    // we put it here statically because we need to accept consent to obtain the iss
-    // and we need the iss to obtain the dynamic scopes and claims for the OIDC server
-    // chicken and egg problem
-    const scopesToClaims = {
-      address: ['address'],
-      email: ['email'],
-      profile: ['birthdate', 'family_name', 'given_name'],
-      age_over_18: ['age_over_18'],
-      age_over_21: ['age_over_21'],
-      age_over_25: ['age_over_25'],
-      payment_details: ['payment_details'],
-      'vc.MockBankCredential': ['vc.MockBankCredential'],
-    };
-    let userinfo_keys = Object.keys(claimsObject.userinfo || {});
-    let id_token_keys = Object.keys(claimsObject.id_token || {});
-    let claims = userinfo_keys.concat(id_token_keys);
+    if (claimsObject && claimsObject.constructor === Object) {
+      // This map comes from core-services/oidc-provider-service/src/services/express/provider.js:50-66
+      // we put it here statically because we need to accept consent to obtain the iss
+      // and we need the iss to obtain the dynamic scopes and claims for the OIDC server
+      // chicken and egg problem
+      const scopesToClaims = {
+        address: ['address'],
+        email: ['email'],
+        profile: ['birthdate', 'family_name', 'given_name'],
+        age_over_18: ['age_over_18'],
+        age_over_21: ['age_over_21'],
+        age_over_25: ['age_over_25'],
+        payment_details: ['payment_details'],
+        'vc.MockBankCredential': ['vc.MockBankCredential'],
+      };
+      let userinfo_keys = Object.keys(claimsObject.userinfo || {});
+      let id_token_keys = Object.keys(claimsObject.id_token || {});
+      let claims = userinfo_keys.concat(id_token_keys);
 
-    const claimsToScopes = Object.keys(scopesToClaims).reduce((acc, scope) => {
-      scopesToClaims[scope].forEach((claim) => {
-        if (!acc[claim]) {
-          acc[claim] = [];
-        }
-        acc[claim].push(scope);
-      });
-      return acc;
-    }, {});
+      const claimsToScopes = Object.keys(scopesToClaims).reduce((acc, scope) => {
+        scopesToClaims[scope].forEach(claim => {
+          if (!acc[claim]) {
+            acc[claim] = [];
+          }
+          acc[claim].push(scope);
+        });
+        return acc;
+      }, {});
 
-    return claims.flatMap(claim => claimsToScopes[claim] || []);
+      return claims.flatMap(claim => claimsToScopes[claim] || []);
+    }
   }
 
   async getAuthorizationUrl(query, proofs, scope, prompt, claims) {

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -137,7 +137,39 @@ class IDPartner {
     };
   }
 
-  async getAuthorizationUrl(query, proofs, scope, prompt) {
+  async #getScopesFromClaims(claimsObject) {
+    // this map comes from core-services/oidc-provider-service/src/services/express/provider.js:50-66
+    // we put it here statically because we need to accept consent to obtain the iss
+    // and we need the iss to obtain the dynamic scopes and claims for the OIDC server
+    // chicken and egg problem
+    const scopesToClaims = {
+      address: ['address'],
+      email: ['email'],
+      profile: ['birthdate', 'family_name', 'given_name'],
+      age_over_18: ['age_over_18'],
+      age_over_21: ['age_over_21'],
+      age_over_25: ['age_over_25'],
+      payment_details: ['payment_details'],
+      'vc.MockBankCredential': ['vc.MockBankCredential'],
+    };
+    let userinfo_keys = Object.keys(claimsObject.userinfo || {});
+    let id_token_keys = Object.keys(claimsObject.id_token || {});
+    let claims = userinfo_keys.concat(id_token_keys);
+
+    const claimsToScopes = Object.keys(scopesToClaims).reduce((acc, scope) => {
+      scopesToClaims[scope].forEach((claim) => {
+        if (!acc[claim]) {
+          acc[claim] = [];
+        }
+        acc[claim].push(scope);
+      });
+      return acc;
+    }, {});
+
+    return claims.flatMap(claim => claimsToScopes[claim] || []);
+  }
+
+  async getAuthorizationUrl(query, proofs, scope, prompt, claims) {
     const { client_id: clientId, account_selector_service_url: accountSelectorServiceUrl, callback: redirectUri } = this.config;
 
     if (!query) throw new Error('The URL query paramaters are required.');
@@ -145,8 +177,12 @@ class IDPartner {
     if (!scope) throw new Error('The scope paramaters are required.');
 
     const { iss, visitor_id: visitorId, idpartner_token: idpartnerToken } = query;
+
+    const scopeFromClaims = await this.#getScopesFromClaims(claims);
+
     if (!iss) {
-      return `${accountSelectorServiceUrl}/auth/select-accounts?client_id=${clientId}&visitor_id=${visitorId}&scope=${scope.join(' ')}`;
+      const fullScope = [...new Set([...scope, ...scopeFromClaims])];
+      return `${accountSelectorServiceUrl}/auth/select-accounts?client_id=${clientId}&visitor_id=${visitorId}&scope=${fullScope.join(' ')}`;
     }
 
     const { state, nonce, codeVerifier } = proofs;
@@ -166,6 +202,7 @@ class IDPartner {
       'x-fapi-interaction-id': uuidv4(),
       identity_provider_id: query.idp_id,
       idpartner_token: idpartnerToken,
+      claims: JSON.stringify(claims),
       ...(this.config.token_endpoint_auth_method === 'client_secret_basic' ? { client_secret: this.config.client_secret } : { response_mode: 'jwt' }),
     };
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -147,40 +147,6 @@ class IDPartner {
     }
   }
 
-  async #mapClaimsToScopes(claimsObject) {
-    if (claimsObject && claimsObject.constructor === Object) {
-      // This map comes from core-services/oidc-provider-service/src/services/express/provider.js:50-66
-      // we put it here statically because we need to accept consent to obtain the iss
-      // and we need the iss to obtain the dynamic scopes and claims for the OIDC server
-      // chicken and egg problem
-      const scopesToClaims = {
-        address: ['address'],
-        email: ['email'],
-        profile: ['birthdate', 'family_name', 'given_name'],
-        age_over_18: ['age_over_18'],
-        age_over_21: ['age_over_21'],
-        age_over_25: ['age_over_25'],
-        payment_details: ['payment_details'],
-        'vc.MockBankCredential': ['vc.MockBankCredential'],
-      };
-      let claims = this.#extractClaims(claimsObject);
-
-      const claimsToScopes = Object.keys(scopesToClaims).reduce((acc, scope) => {
-        scopesToClaims[scope].forEach(claim => {
-          if (!acc[claim]) {
-            acc[claim] = [];
-          }
-          acc[claim].push(scope);
-        });
-        return acc;
-      }, {});
-
-      return claims.flatMap(claim => claimsToScopes[claim] || []);
-    } else {
-      return [];
-    }
-  }
-
   async getAuthorizationUrl(query, proofs, scope, prompt, claimsObject) {
     const { client_id: clientId, account_selector_service_url: accountSelectorServiceUrl, callback: redirectUri } = this.config;
 
@@ -191,7 +157,6 @@ class IDPartner {
     const { iss, visitor_id: visitorId, idpartner_token: idpartnerToken } = query;
 
     const claims = this.#extractClaims(claimsObject);
-    const claimsMappedToScopes = await this.#mapClaimsToScopes(claimsObject);
 
     if (!iss) {
       return `${accountSelectorServiceUrl}/auth/select-accounts?client_id=${clientId}&visitor_id=${visitorId}&scope=${scope.join(' ')}&claims=${claims.join(' ')}`;
@@ -215,7 +180,6 @@ class IDPartner {
       identity_provider_id: query.idp_id,
       idpartner_token: idpartnerToken,
       claims: JSON.stringify(claimsObject),
-      claims_mapped_to_scopes: claimsMappedToScopes.join(' '),
       ...(this.config.token_endpoint_auth_method === 'client_secret_basic' ? { client_secret: this.config.client_secret } : { response_mode: 'jwt' }),
     };
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -137,7 +137,17 @@ class IDPartner {
     };
   }
 
-  async #getScopesFromClaims(claimsObject) {
+  #extractClaims(claimsObject) {
+    if (claimsObject && claimsObject.constructor === Object) {
+      let userinfo_keys = Object.keys(claimsObject.userinfo || {});
+      let id_token_keys = Object.keys(claimsObject.id_token || {});
+      return userinfo_keys.concat(id_token_keys);
+    } else {
+      return [];
+    }
+  }
+
+  async #mapClaimsToScopes(claimsObject) {
     if (claimsObject && claimsObject.constructor === Object) {
       // This map comes from core-services/oidc-provider-service/src/services/express/provider.js:50-66
       // we put it here statically because we need to accept consent to obtain the iss
@@ -153,9 +163,7 @@ class IDPartner {
         payment_details: ['payment_details'],
         'vc.MockBankCredential': ['vc.MockBankCredential'],
       };
-      let userinfo_keys = Object.keys(claimsObject.userinfo || {});
-      let id_token_keys = Object.keys(claimsObject.id_token || {});
-      let claims = userinfo_keys.concat(id_token_keys);
+      let claims = this.#extractClaims(claimsObject);
 
       const claimsToScopes = Object.keys(scopesToClaims).reduce((acc, scope) => {
         scopesToClaims[scope].forEach(claim => {
@@ -168,10 +176,12 @@ class IDPartner {
       }, {});
 
       return claims.flatMap(claim => claimsToScopes[claim] || []);
+    } else {
+      return [];
     }
   }
 
-  async getAuthorizationUrl(query, proofs, scope, prompt, claims) {
+  async getAuthorizationUrl(query, proofs, scope, prompt, claimsObject) {
     const { client_id: clientId, account_selector_service_url: accountSelectorServiceUrl, callback: redirectUri } = this.config;
 
     if (!query) throw new Error('The URL query paramaters are required.');
@@ -180,11 +190,11 @@ class IDPartner {
 
     const { iss, visitor_id: visitorId, idpartner_token: idpartnerToken } = query;
 
-    const scopeFromClaims = await this.#getScopesFromClaims(claims);
-    const extendedScopes = [...new Set([...scope, ...scopeFromClaims])];
+    const claims = this.#extractClaims(claimsObject);
+    const claimsMappedToScopes = await this.#mapClaimsToScopes(claimsObject);
 
     if (!iss) {
-      return `${accountSelectorServiceUrl}/auth/select-accounts?client_id=${clientId}&visitor_id=${visitorId}&scope=${extendedScopes.join(' ')}`;
+      return `${accountSelectorServiceUrl}/auth/select-accounts?client_id=${clientId}&visitor_id=${visitorId}&scope=${scope.join(' ')}&claims=${claims.join(' ')}`;
     }
 
     const { state, nonce, codeVerifier } = proofs;
@@ -196,7 +206,7 @@ class IDPartner {
       code_challenge: codeChallenge,
       state,
       nonce,
-      scope: extendedScopes.join(' '),
+      scope: scope.join(' '),
       prompt,
       response_type: 'code',
       client_id: clientId,
@@ -204,7 +214,8 @@ class IDPartner {
       'x-fapi-interaction-id': uuidv4(),
       identity_provider_id: query.idp_id,
       idpartner_token: idpartnerToken,
-      claims: JSON.stringify(claims),
+      claims: JSON.stringify(claimsObject),
+      claims_mapped_to_scopes: claimsMappedToScopes.join(' '),
       ...(this.config.token_endpoint_auth_method === 'client_secret_basic' ? { client_secret: this.config.client_secret } : { response_mode: 'jwt' }),
     };
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -141,7 +141,7 @@ class IDPartner {
     if (claimsObject && claimsObject.constructor === Object) {
       let userinfo_keys = Object.keys(claimsObject.userinfo || {});
       let id_token_keys = Object.keys(claimsObject.id_token || {});
-      return userinfo_keys.concat(id_token_keys);
+      return [...new Set([...userinfo_keys, ...id_token_keys])];
     } else {
       return [];
     }

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -181,10 +181,10 @@ class IDPartner {
     const { iss, visitor_id: visitorId, idpartner_token: idpartnerToken } = query;
 
     const scopeFromClaims = await this.#getScopesFromClaims(claims);
+    const extendedScopes = [...new Set([...scope, ...scopeFromClaims])];
 
     if (!iss) {
-      const fullScope = [...new Set([...scope, ...scopeFromClaims])];
-      return `${accountSelectorServiceUrl}/auth/select-accounts?client_id=${clientId}&visitor_id=${visitorId}&scope=${fullScope.join(' ')}`;
+      return `${accountSelectorServiceUrl}/auth/select-accounts?client_id=${clientId}&visitor_id=${visitorId}&scope=${extendedScopes.join(' ')}`;
     }
 
     const { state, nonce, codeVerifier } = proofs;
@@ -196,7 +196,7 @@ class IDPartner {
       code_challenge: codeChallenge,
       state,
       nonce,
-      scope: scope.join(' '),
+      scope: extendedScopes.join(' '),
       prompt,
       response_type: 'code',
       client_id: clientId,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {

--- a/test/idpartner.test.js
+++ b/test/idpartner.test.js
@@ -263,7 +263,7 @@ describe('id-partner', function () {
     test('calls the correct underlying library functions and returns a valid url when claims parameter is undefined', async () => {
       const consent = 'prompt';
       const proofs = ipd.generateProofs();
-      const claims = undefined
+      const claims = undefined;
       const url = await ipd.getAuthorizationUrl({ iss: ISSUER, visitor_id: VISITOR_ID }, proofs, ['openid'], consent, claims);
 
       // Validates that client is correctly initialized

--- a/test/idpartner.test.js
+++ b/test/idpartner.test.js
@@ -60,6 +60,16 @@ const ISSUER_TOKEN_RESPONSE = {
   token_type: 'Bearer',
   claims: jest.fn(),
 };
+const CLAIMS = {
+  id_token: {
+    email: {
+      essential: true,
+    },
+  },
+  userinfo: {
+    payment_details: null,
+  },
+};
 
 describe('id-partner', function () {
   let issuerMock;
@@ -229,6 +239,54 @@ describe('id-partner', function () {
         request_uri: ISSUER_PAR_RESPONSE.request_uri,
       });
       expect(url).toBe(`${ISSUER_AUTH_ENDPOINT}?${queryParams.toString()}`);
+    });
+
+    test('calls the correct underlying library functions and returns a valid url when claims parameter is used', async () => {
+      const consent = 'prompt';
+      const proofs = ipd.generateProofs();
+      const claims = CLAIMS;
+      const url = await ipd.getAuthorizationUrl({ iss: ISSUER, visitor_id: VISITOR_ID }, proofs, ['openid'], consent, claims);
+
+      // Validates that client is correctly initialized
+      assertIssuerDiscoveryAndClientInitialization();
+
+      // Validates that request object and PAR is made
+      assertRequestObjectCreationAndPushedAuthRequest({ proofs, consent });
+
+      // Validates the response is the url we expect
+      const queryParams = new URLSearchParams({
+        request_uri: ISSUER_PAR_RESPONSE.request_uri,
+      });
+      expect(url).toBe(`${ISSUER_AUTH_ENDPOINT}?${queryParams.toString()}`);
+    });
+
+    test('calls the correct underlying library functions and returns a valid url when claims parameter is undefined', async () => {
+      const consent = 'prompt';
+      const proofs = ipd.generateProofs();
+      const claims = undefined
+      const url = await ipd.getAuthorizationUrl({ iss: ISSUER, visitor_id: VISITOR_ID }, proofs, ['openid'], consent, claims);
+
+      // Validates that client is correctly initialized
+      assertIssuerDiscoveryAndClientInitialization();
+
+      // Validates that request object and PAR is made
+      assertRequestObjectCreationAndPushedAuthRequest({ proofs, consent });
+
+      // Validates the response is the url we expect
+      const queryParams = new URLSearchParams({
+        request_uri: ISSUER_PAR_RESPONSE.request_uri,
+      });
+      expect(url).toBe(`${ISSUER_AUTH_ENDPOINT}?${queryParams.toString()}`);
+    });
+
+    test('returns the converted claims into scopes when claims paramaeter is used', async () => {
+      const consent = 'prompt';
+      const proofs = ipd.generateProofs();
+      const claims = CLAIMS;
+      const url = await ipd.getAuthorizationUrl({ visitor_id: VISITOR_ID }, proofs, ['openid'], consent, claims);
+
+      // Validates the response is the url we expect
+      expect(url).toBe(`${ACCOUNT_SELECTOR}/auth/select-accounts?client_id=${CLIENT_ID}&visitor_id=${VISITOR_ID}&scope=openid payment_details email`);
     });
   });
 

--- a/test/idpartner.test.js
+++ b/test/idpartner.test.js
@@ -286,7 +286,7 @@ describe('id-partner', function () {
       const url = await ipd.getAuthorizationUrl({ visitor_id: VISITOR_ID }, proofs, ['openid'], consent, claims);
 
       // Validates the response is the url we expect
-      expect(url).toBe(`${ACCOUNT_SELECTOR}/auth/select-accounts?client_id=${CLIENT_ID}&visitor_id=${VISITOR_ID}&scope=openid payment_details email`);
+      expect(url).toBe(`${ACCOUNT_SELECTOR}/auth/select-accounts?client_id=${CLIENT_ID}&visitor_id=${VISITOR_ID}&scope=openid&claims=payment_details email`);
     });
   });
 


### PR DESCRIPTION
Support to send the `claims` parameter to the OIDC server's authorizationURL. Additionally, add some logic to convert the `claims` parameter in an array. The claims array is used by our consent screen.