### PR TITLE
DEV-750 Always sends response_mode jwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+3.0.6
+- Always sends response_mode jwt, due to FAPI 1.0 AF
+
 3.0.5
 - Add claims parameter support
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -180,7 +180,7 @@ class IDPartner {
       identity_provider_id: query.idp_id,
       idpartner_token: idpartnerToken,
       claims: JSON.stringify(claimsObject),
-      ...(this.config.token_endpoint_auth_method === 'client_secret_basic' ? { client_secret: this.config.client_secret } : { response_mode: 'jwt' }),
+      response_mode: 'jwt',
     };
 
     let pushedAuthorizationRequestParams = authorizationParams;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {


### PR DESCRIPTION
Panva lib requires to use JWT when Fapi is on:
https://github.com/panva/node-oidc-provider/blob/main/lib/actions/authorization/check_response_mode.js#L52

Related PRs:
https://github.com/idpartner-app/idpartner/pull/607
https://github.com/idpartner-app/identity-provider-services/pull/109
