### PR TITLE
Make the account selector url fully customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+5.0.0
+- Make account selector URL fully customizable
+
 4.0.0
 - Add support for sending extra authorization params to the OP
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -87,7 +87,7 @@ class IDPartner {
 
     const defaultConfig = {
       // generic config
-      account_selector_service_url: 'https://auth-api.idpartner.com/oidc-proxy',
+      account_selector_service_url: 'https://preferences.idpartner.com/v1/select-accounts',
       token_endpoint_auth_method: 'client_secret_basic',
       jwks: undefined,
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -159,7 +159,7 @@ class IDPartner {
     const scopeString = typeof scope === 'string' ? scope : scope.join(' ');
     const { iss, visitor_id: visitorId, idpartner_token: idpartnerToken } = query;
     if (!iss) {
-      return `${accountSelectorServiceUrl}/auth/select-accounts?client_id=${clientId}&visitor_id=${visitorId}&scope=${scopeString}&claims=${claimsString}`;
+      return `${accountSelectorServiceUrl}?client_id=${clientId}&visitor_id=${visitorId}&scope=${scopeString}&claims=${claimsString}`;
     }
 
     const { state, nonce, codeVerifier } = proofs;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {

--- a/test/idpartner.test.js
+++ b/test/idpartner.test.js
@@ -16,7 +16,7 @@ const {
 
 jest.mock('openid-client');
 
-const ACCOUNT_SELECTOR = 'https://account-selector.com';
+const ACCOUNT_SELECTOR = 'https://account-selector.com/auth/select-accounts';
 const CLIENT_ID = 'mXzJ0TJEbWQb2A8s1z6gq';
 const CLIENT_SECRET = uuidv4();
 const CALLBACK_URI = 'http://myapplication.com';
@@ -326,7 +326,7 @@ describe('idpartner', function () {
 
         // Validates the response is the url we expect
         expect(url).toBe(
-          `${idpartnerClientSecretConfig.account_selector_service_url}/auth/select-accounts?client_id=${idpartnerClientSecretConfig.client_id}&visitor_id=${VISITOR_ID}&scope=openid&claims=payment_details email`,
+          `${idpartnerClientSecretConfig.account_selector_service_url}?client_id=${idpartnerClientSecretConfig.client_id}&visitor_id=${VISITOR_ID}&scope=openid&claims=payment_details email`,
         );
       });
     });


### PR DESCRIPTION
Make the account selector url fully customizable. Assuming a path exists in a service limits the flexibility of our library.