### PR TITLE
DEV-1458 Enable account selection in the oidc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+5.0.1
+- Add adobe flow parameters to allow account selection after hitting the IDPartner's OIDC
+
 5.0.0
 - Make account selector URL fully customizable
 

--- a/lib/idpartner.js
+++ b/lib/idpartner.js
@@ -117,7 +117,11 @@ class IDPartner {
 
   async #getAccessToken(client, codeResponse, { state, nonce, codeVerifier }, options = {}) {
     const params = client.callbackParams(codeResponse);
-    return client.callback(client.redirect_uris[0], params, { state, nonce, code_verifier: codeVerifier }, options);
+    let pkceParams = {};
+    if (!this.config.delegatedAccountSelection) {
+      pkceParams = { code_verifier: codeVerifier };
+    }
+    return client.callback(client.redirect_uris[0], params, { state, nonce, ...pkceParams }, options);
   }
 
   async getPublicJWKs() {
@@ -157,18 +161,31 @@ class IDPartner {
     const claimsArray = this.#extractClaims(claims);
     const claimsString = claimsArray.join(' ');
     const scopeString = typeof scope === 'string' ? scope : scope.join(' ');
-    const { iss, visitor_id: visitorId, idpartner_token: idpartnerToken } = query;
+    let iss = query.iss;
+    const { visitor_id: visitorId, idpartner_token: idpartnerToken } = query;
+    // Modify PKCE related code based on the use_pkce config
+    let extraParams = {};
+    if (this.config.delegatedAccountSelection) {
+      extraParams = { visitor_id: visitorId };
+    } else {
+      const { codeVerifier } = proofs;
+      const codeChallenge = generators.codeChallenge(codeVerifier);
+      extraParams = {
+        code_challenge_method: 'S256',
+        code_challenge: codeChallenge,
+      };
+    }
+    if (this.config.delegatedAccountSelection) {
+      iss = this.config.iss;
+    }
     if (!iss) {
       return `${accountSelectorServiceUrl}?client_id=${clientId}&visitor_id=${visitorId}&scope=${scopeString}&claims=${claimsString}`;
     }
 
-    const { state, nonce, codeVerifier } = proofs;
-    const codeChallenge = generators.codeChallenge(codeVerifier);
+    const { state, nonce } = proofs;
     const client = await this.#getClient(iss);
     const authorizationParams = {
       redirect_uri: redirectUri,
-      code_challenge_method: 'S256',
-      code_challenge: codeChallenge,
       state,
       nonce,
       scope: scopeString,
@@ -176,10 +193,11 @@ class IDPartner {
       client_id: clientId,
       nbf: Math.floor(new Date().getTime() / 1000),
       'x-fapi-interaction-id': uuidv4(),
-      identity_provider_id: query.idp_id,
+      identity_provider_id: query.idp_id || query.saved_provider_id,
       idpartner_token: idpartnerToken,
       response_mode: 'jwt',
       claims: JSON.stringify(claims),
+      ...extraParams,
       ...otherAuthorizationParams,
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idpartner/node-oidc-client",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A node module for authentication and use with the IDPartner API",
   "main": "./lib/idpartner",
   "scripts": {


### PR DESCRIPTION
Adobe requested to have the account selection inside the oidc call we filter out providers that use a different OIDC node than IDPartner one to prevent problems with JWKs

https://identity-online.atlassian.net/browse/DEV-1458